### PR TITLE
ci: allow manual run for unpack workflow

### DIFF
--- a/.github/workflows/unpack.yml
+++ b/.github/workflows/unpack.yml
@@ -1,5 +1,6 @@
 name: Unpack CoreAlpha Adapter ZIP
 on:
+  workflow_dispatch:
   push:
     paths:
       - "corealpha_end2end_v1_1.zip"


### PR DESCRIPTION
## Summary
- allow manual invocation of unpack workflow

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1b2e7267c83268b79f6196ecc977b