### PR TITLE
ci: add Dockerfile + GHCR publish and Vercel deploy workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,41 @@
+name: Docker Publish (Adapter)
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - "frontend/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/corealpha-adapter
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ui-deploy-vercel.yml
+++ b/.github/workflows/ui-deploy-vercel.yml
@@ -1,0 +1,36 @@
+name: Deploy Frontend to Vercel
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "frontend/**"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: "frontend/package-lock.json"
+      - name: Install deps
+        run: |
+          if [ -f package-lock.json ]; then npm ci; else npm install; fi
+      - name: Build (if present)
+        run: npm run build --if-present
+      - name: Deploy with Vercel CLI
+        run: |
+          npm i -g vercel@latest
+          vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+          vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# System deps (uvicorn needs build base for some wheels occasionally)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential curl && rm -rf /var/lib/apt/lists/*
+
+# Copy requirement files first (for caching)
+COPY requirements.txt ./requirements.txt
+RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+RUN pip install uvicorn fastapi
+
+# Copy source
+COPY . .
+
+# Ensure start script is executable
+RUN chmod +x docker/start.sh
+
+EXPOSE 8000
+ENV HOST=0.0.0.0 PORT=8000
+
+# Allow override via APP_MODULE, otherwise auto-detect in start_app.py
+CMD ["bash", "docker/start.sh"]

--- a/README.md
+++ b/README.md
@@ -6,3 +6,25 @@ pip install -r requirements.txt -r requirements-dev.txt
 pre-commit install           # aktiverar hooks lokalt
 pre-commit run --all-files   # kör på hela repo
 pytest -q
+
+## Run & Deploy
+
+### Run (Docker)
+```
+docker run -p 8000:8000 ghcr.io/fatdevil/corealpha-adapter:latest
+# eller bygg lokalt:
+docker build -t corealpha-adapter .
+docker run -p 8000:8000 corealpha-adapter
+```
+
+### Env
+```
+# sätt APP_MODULE om du vill peka explicit:
+# docker run -e APP_MODULE="core.main:app" -p 8000:8000 ghcr.io/fatdevil/corealpha-adapter:latest
+```
+
+### Frontend deploy (Vercel)
+```
+# Lägg GitHub Secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID
+# Push till main under frontend/ triggar deploy-workflow.
+```

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONUNBUFFERED=1
+python docker/start_app.py

--- a/docker/start_app.py
+++ b/docker/start_app.py
@@ -1,0 +1,56 @@
+import pathlib, importlib, re, os, sys
+
+
+def find_fastapi_app():
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    candidates = []
+    for py in repo.rglob("*.py"):
+        try:
+            text = py.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            continue
+        if "FastAPI(" in text:
+            m = re.search(r'(?m)^\s*([a-zA-Z_]\w*)\s*=\s*FastAPI\(', text)
+            if m:
+                varname = m.group(1)
+                module = (
+                    py.relative_to(repo)
+                    .with_suffix("")
+                    .as_posix()
+                    .replace("/", ".")
+                )
+                candidates.append((module, varname))
+    for module, varname in candidates:
+        mod = importlib.import_module(module)
+        app = getattr(mod, varname, None)
+        # Late import to avoid hard dep when scanning
+        from fastapi import FastAPI  # type: ignore
+        if isinstance(app, FastAPI):
+            return module, varname
+    return None, None
+
+
+def main():
+    # Allow explicit override: APP_MODULE="path.to.module:appvar"
+    override = os.getenv("APP_MODULE")
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    reload_opt = os.getenv("UVICORN_RELOAD", "false").lower() == "true"
+
+    if override:
+        module, var = override.split(":")
+    else:
+        module, var = find_fastapi_app()
+        if not module:
+            print("No FastAPI app found. Set APP_MODULE='pkg.module:app'", file=sys.stderr)
+            sys.exit(1)
+
+    import uvicorn  # type: ignore
+
+    uvicorn.run(
+        f"{module}:{var}", host=host, port=port, reload=reload_opt, log_level="info"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Dockerfile and helper scripts to auto-detect and run the FastAPI app with Uvicorn
- configure GitHub Actions workflow to build and publish the adapter image to GHCR
- add Vercel deployment workflow for the frontend and document Docker/Vercel usage in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d01741c00c8326be5322be212d7f02