### PR TITLE
ops: release-please + compose + devcontainer + templates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "CoreAlpha Dev",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" }
+  },
+  "postCreateCommand": "pip install -r requirements.txt -r requirements-dev.txt && pre-commit install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "esbenp.prettier-vscode",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env and adjust if needed
+APP_MODULE=corealpha_adapter.app:app
+GITHUB_USER=fatdevil

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,15 @@
+---
+name: Bug report
+about: Report a bug in Corealpha
+title: "[BUG] <title>"
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+## Steps to reproduce
+
+## Expected behavior
+
+## Additional context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## What
+- 
+
+## Why
+- 
+
+## Tests
+- [ ] `pytest -q`
+- [ ] `pre-commit run --all-files`

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,16 @@
+name: release-please
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: simple
+          package-name: corealpha

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Corealpha-FT-HF
 
+![CI](https://github.com/Fatdevil/Corealpha-FT-HF/actions/workflows/ci.yml/badge.svg)
+![Lint](https://github.com/Fatdevil/Corealpha-FT-HF/actions/workflows/lint.yml/badge.svg)
+![E2E](https://github.com/Fatdevil/Corealpha-FT-HF/actions/workflows/e2e-adapter.yml/badge.svg)
+
 ## Dev setup (lint & tests)
 python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt -r requirements-dev.txt
@@ -16,6 +20,13 @@ docker run -e APP_MODULE="corealpha_adapter.app:app" -p 8000:8000 ghcr.io/fatdev
 docker build -t corealpha-adapter .
 docker run -p 8000:8000 corealpha-adapter
 ```
+
+### Run locally
+
+# with GHCR image
+cp .env.example .env
+docker compose up -d
+open http://localhost:8000/healthz
 
 ### Env
 ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,13 @@
+services:
+  adapter:
+    image: ghcr.io/${GITHUB_USER:-fatdevil}/corealpha-adapter:latest
+    ports: ["8000:8000"]
+    environment:
+      APP_MODULE: ${APP_MODULE:-corealpha_adapter.app:app}
+      HOST: 0.0.0.0
+      PORT: 8000
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/healthz"]
+      interval: 5s
+      timeout: 2s
+      retries: 20


### PR DESCRIPTION
## Summary
- add release-please workflow for automated releases
- add compose setup, environment example, and README guidance for local runs
- add devcontainer configuration plus repository issue and PR templates

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68d0398b6df08326a6909fc0b3fa2143