### PR TITLE
chore(deps): rollup 2025-09-22 (uvicorn 0.36.0, black 25.9.0, flake8 7.3.0)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,17 +7,17 @@ repos:
       - id: check-ast
       - id: detect-private-key
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 25.9.0
     hooks:
       - id: black
         args: ["--line-length=100"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         args: ["--profile", "black", "--line-length", "100"]
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         additional_dependencies: []

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 pre-commit
-black==24.8.0
+black==25.9.0
 isort==6.0.1
-flake8==7.1.0
+flake8==7.3.0
 pytest
 httpx
 pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ prometheus-fastapi-instrumentator==7.1.0
 secure==0.3.0
 slowapi==0.1.9
 structlog==24.1.0
-uvicorn[standard]==0.30.6
+uvicorn[standard]==0.36.0
 httpx==0.27.2


### PR DESCRIPTION
## Summary
- bump uvicorn runtime dependency to 0.36.0
- update development tooling pins for black 25.9.0, flake8 7.3.0, and pre-commit isort hook 6.0.1

## Testing
- pre-commit run --all-files --show-diff-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d18506ab4483268cdfaa3b14e7a2ff